### PR TITLE
Add Packrift OR-Tools carton selection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ More advanced or complex examples usually merging few concepts and available (i.
 - [Contrib examples](https://github.com/google/or-tools/tree/stable/examples/contrib) Community contributed examples.
 - [Hakank's examples](https://github.com/hakank/hakank/tree/main/google_or_tools) Dozens of combinatorial problems and puzzles.
 - [MrBenGriffin's examples](https://github.com/MrBenGriffin/or-tools-fun) Models (Delegate Seating) and puzzle solvers.
+- [Packrift carton selection example](https://github.com/Packrift/packaging-optimization-benchmark-corpus/tree/main/examples/ortools-carton-selection) CP-SAT example that screens static packaging carton candidates by orientation and relaxed volume constraints.
 
 ### Internal
 


### PR DESCRIPTION
Adds a CP-SAT example using a small static Packrift carton dataset to select the smallest feasible carton after orientation and relaxed volume screens.

The linked example includes runnable Python code, sample CSV data, and explicit limitations: it is a screening model, not a live pricing, inventory, freight, checkout, or final fit approval engine.